### PR TITLE
Handle categorical team features and clean game ensemble

### DIFF
--- a/MLB_SPORTSBETTING.py
+++ b/MLB_SPORTSBETTING.py
@@ -493,6 +493,18 @@ def train_and_predict_games_ensemble(
     """
     X_today = X_today[X.columns]
 
+    # Drop constant features that provide no information
+    bad_cols = [c for c in X.columns if X[c].nunique() <= 1]
+    if bad_cols:
+        X = X.drop(columns=bad_cols)
+        X_today = X_today.drop(columns=bad_cols, errors='ignore')
+
+    # Treat team identifiers as categorical for LightGBM
+    cat_cols = [c for c in ['away_team_id', 'home_team_id'] if c in X.columns]
+    for df in (X, X_today):
+        for c in cat_cols:
+            df[c] = df[c].astype('category')
+
     # 1) Fit GLM pipelines
     glm_away = Pipeline([('scaler', StandardScaler()), ('model', PoissonRegressor(alpha=0.0, max_iter=2000))])
     glm_home = Pipeline([('scaler', StandardScaler()), ('model', PoissonRegressor(alpha=0.0, max_iter=2000))])
@@ -501,14 +513,19 @@ def train_and_predict_games_ensemble(
     # 2) Fit GBMs
     gbm_away = lgb.LGBMRegressor(objective='poisson', n_estimators=300, learning_rate=0.05)
     gbm_home = lgb.LGBMRegressor(objective='poisson', n_estimators=300, learning_rate=0.05)
-    gbm_away.fit(X, y['away_score']); gbm_home.fit(X, y['home_score'])
+    gbm_away.fit(X, y['away_score'], categorical_feature=cat_cols)
+    gbm_home.fit(X, y['home_score'], categorical_feature=cat_cols)
 
     # 3) Cross-validate
     kf = KFold(n_splits=5, shuffle=True, random_state=42)
     cv_glm_away = -cross_val_score(glm_away.named_steps['model'], X, y['away_score'], cv=kf, scoring='neg_mean_poisson_deviance')
-    cv_gbm_away = -cross_val_score(gbm_away, X, y['away_score'], cv=kf, scoring='neg_mean_poisson_deviance')
+    cv_gbm_away = -cross_val_score(gbm_away, X, y['away_score'], cv=kf,
+                                   scoring='neg_mean_poisson_deviance',
+                                   fit_params={'categorical_feature': cat_cols})
     cv_glm_home = -cross_val_score(glm_home.named_steps['model'], X, y['home_score'], cv=kf, scoring='neg_mean_poisson_deviance')
-    cv_gbm_home = -cross_val_score(gbm_home, X, y['home_score'], cv=kf, scoring='neg_mean_poisson_deviance')
+    cv_gbm_home = -cross_val_score(gbm_home, X, y['home_score'], cv=kf,
+                                   scoring='neg_mean_poisson_deviance',
+                                   fit_params={'categorical_feature': cat_cols})
 
     # 4) Compute weights and raw lambdas
     w_glm_away = cv_gbm_away.mean() / (cv_glm_away.mean() + cv_gbm_away.mean())
@@ -516,13 +533,14 @@ def train_and_predict_games_ensemble(
     w_glm_home = cv_gbm_home.mean() / (cv_glm_home.mean() + cv_gbm_home.mean())
     w_gbm_home = cv_glm_home.mean() / (cv_glm_home.mean() + cv_gbm_home.mean())
 
-    lam_away_glm   = glm_away.predict(X_today)
+    # PoissonRegressor outputs log-lambda; exponentiate to get expected runs
+    lam_away_glm   = np.exp(glm_away.predict(X_today))
     lam_away_gbm   = gbm_away.predict(X_today)
-    lam_home_glm   = glm_home.predict(X_today)
+    lam_home_glm   = np.exp(glm_home.predict(X_today))
     lam_home_gbm   = gbm_home.predict(X_today)
-    lam_away_glm_tr = glm_away.predict(X)
+    lam_away_glm_tr = np.exp(glm_away.predict(X))
     lam_away_gbm_tr = gbm_away.predict(X)
-    lam_home_glm_tr = glm_home.predict(X)
+    lam_home_glm_tr = np.exp(glm_home.predict(X))
     lam_home_gbm_tr = gbm_home.predict(X)
 
     # 5) Ensemble

--- a/MLB_SPORTSBETTING.py
+++ b/MLB_SPORTSBETTING.py
@@ -511,21 +511,31 @@ def train_and_predict_games_ensemble(
     glm_away.fit(X, y['away_score']); glm_home.fit(X, y['home_score'])
 
     # 2) Fit GBMs
-    gbm_away = lgb.LGBMRegressor(objective='poisson', n_estimators=300, learning_rate=0.05)
-    gbm_home = lgb.LGBMRegressor(objective='poisson', n_estimators=300, learning_rate=0.05)
-    gbm_away.fit(X, y['away_score'], categorical_feature=cat_cols)
-    gbm_home.fit(X, y['home_score'], categorical_feature=cat_cols)
+    gbm_away = lgb.LGBMRegressor(
+        objective='poisson', n_estimators=300, learning_rate=0.05,
+        categorical_feature=cat_cols
+    )
+    gbm_home = lgb.LGBMRegressor(
+        objective='poisson', n_estimators=300, learning_rate=0.05,
+        categorical_feature=cat_cols
+    )
+    gbm_away.fit(X, y['away_score'])
+    gbm_home.fit(X, y['home_score'])
 
     # 3) Cross-validate
     kf = KFold(n_splits=5, shuffle=True, random_state=42)
-    cv_glm_away = -cross_val_score(glm_away.named_steps['model'], X, y['away_score'], cv=kf, scoring='neg_mean_poisson_deviance')
-    cv_gbm_away = -cross_val_score(gbm_away, X, y['away_score'], cv=kf,
-                                   scoring='neg_mean_poisson_deviance',
-                                   fit_params={'categorical_feature': cat_cols})
-    cv_glm_home = -cross_val_score(glm_home.named_steps['model'], X, y['home_score'], cv=kf, scoring='neg_mean_poisson_deviance')
-    cv_gbm_home = -cross_val_score(gbm_home, X, y['home_score'], cv=kf,
-                                   scoring='neg_mean_poisson_deviance',
-                                   fit_params={'categorical_feature': cat_cols})
+    cv_glm_away = -cross_val_score(
+        glm_away, X, y['away_score'], cv=kf, scoring='neg_mean_poisson_deviance'
+    )
+    cv_gbm_away = -cross_val_score(
+        gbm_away, X, y['away_score'], cv=kf, scoring='neg_mean_poisson_deviance'
+    )
+    cv_glm_home = -cross_val_score(
+        glm_home, X, y['home_score'], cv=kf, scoring='neg_mean_poisson_deviance'
+    )
+    cv_gbm_home = -cross_val_score(
+        gbm_home, X, y['home_score'], cv=kf, scoring='neg_mean_poisson_deviance'
+    )
 
     # 4) Compute weights and raw lambdas
     w_glm_away = cv_gbm_away.mean() / (cv_glm_away.mean() + cv_gbm_away.mean())


### PR DESCRIPTION
## Summary
- Drop constant columns and mark team identifiers as categorical for LightGBM
- Pass categorical info through fit/cross-validation and exponentiate Poisson predictions

## Testing
- `python -m py_compile MLB_SPORTSBETTING.py`


------
https://chatgpt.com/codex/tasks/task_e_689e2337a7b88330aee1b2a40b95ddfd